### PR TITLE
对DBHelper添加无需借助实体类达到批量插入Map或Object列表的接口

### DIFF
--- a/nimble-orm-test/src/test/java/com/pugwoo/dbhelper/test/test_common/Test2Insert.java
+++ b/nimble-orm-test/src/test/java/com/pugwoo/dbhelper/test/test_common/Test2Insert.java
@@ -73,6 +73,33 @@ public class Test2Insert {
         assert rows == TOTAL;
     }
 
+    @Test
+    public void testInsertBatchWithoutReturnIdWithMapList() {
+        int TOTAL = 1000;
+
+        List<Map<String, Object>> list = new ArrayList<>();
+        for (int i = 0; i < TOTAL; i++) {
+            Map<String, Object> studentMap = new HashMap<>();
+            studentMap.put("name", uuidName());
+            studentMap.put("age", 0);
+            list.add(studentMap);
+        }
+
+        dbHelper.setTimeoutWarningValve(1); // 改小超时阈值，让慢sql打印出来
+
+        long start = System.currentTimeMillis();
+        int rows = dbHelper.insertBatchWithoutReturnId("t_student", list);
+        long end = System.currentTimeMillis();
+        System.out.println("batch insert cost:" + (end - start) + "ms");
+        assert rows == TOTAL;
+
+        start = System.currentTimeMillis();
+        rows = dbHelper.insertBatchWithoutReturnId("t_student", new HashSet<>(list));
+        end = System.currentTimeMillis();
+        System.out.println("batch insert cost:" + (end - start) + "ms");
+        assert rows == TOTAL;
+    }
+
     /**测试插入时指定了id，依然可以准确获得id的场景*/
     @Transactional // 开启事务是为了让下面的测试共用一个连接，而不是因为获取自增id需要事务
     @Rollback(false)

--- a/nimble-orm-test/src/test/java/com/pugwoo/dbhelper/test/test_common/Test2Insert.java
+++ b/nimble-orm-test/src/test/java/com/pugwoo/dbhelper/test/test_common/Test2Insert.java
@@ -47,7 +47,7 @@ public class Test2Insert {
         assert st.getName() == null;
     }
 
-    @Test 
+    @Test
     public void testBatchInsert() {
         int TOTAL = 1000;
 
@@ -76,12 +76,12 @@ public class Test2Insert {
     @Test
     public void testInsertBatchWithoutReturnIdWithMapList() {
         int TOTAL = 1000;
-
+        Random random = new Random();
         List<Map<String, Object>> list = new ArrayList<>();
         for (int i = 0; i < TOTAL; i++) {
             Map<String, Object> studentMap = new HashMap<>();
-            studentMap.put("name", uuidName());
             studentMap.put("age", 0);
+            studentMap.put("school_id", random.nextInt());
             list.add(studentMap);
         }
 
@@ -95,6 +95,34 @@ public class Test2Insert {
 
         start = System.currentTimeMillis();
         rows = dbHelper.insertBatchWithoutReturnId("t_student", new HashSet<>(list));
+        end = System.currentTimeMillis();
+        System.out.println("batch insert cost:" + (end - start) + "ms");
+        assert rows == TOTAL;
+    }
+
+    @Test
+    public void testInsertBatchWithoutReturnIdWithColsAndData() {
+        int TOTAL = 1000;
+        Random random = new Random();
+        List<String> cols = new ArrayList<>();
+        cols.add("age");
+        cols.add("school_id");
+        List<Object[]> data = new ArrayList<>();
+        for (int i = 0; i < TOTAL; i++) {
+            Object[] args = new Object[]{"0", random.nextInt()};
+            data.add(args);
+        }
+
+        dbHelper.setTimeoutWarningValve(1); // 改小超时阈值，让慢sql打印出来
+
+        long start = System.currentTimeMillis();
+        int rows = dbHelper.insertBatchWithoutReturnId("t_student", cols, data);
+        long end = System.currentTimeMillis();
+        System.out.println("batch insert cost:" + (end - start) + "ms");
+        assert rows == TOTAL;
+
+        start = System.currentTimeMillis();
+        rows = dbHelper.insertBatchWithoutReturnId("t_student", cols, data);
         end = System.currentTimeMillis();
         System.out.println("batch insert cost:" + (end - start) + "ms");
         assert rows == TOTAL;

--- a/nimble-orm/src/main/java/com/pugwoo/dbhelper/DBHelper.java
+++ b/nimble-orm/src/main/java/com/pugwoo/dbhelper/DBHelper.java
@@ -447,6 +447,23 @@ public interface DBHelper {
 	<T> int insertBatchWithoutReturnId(Collection<T> list);
 
 	/**
+	 * 批量插入多条记录，返回数据库实际修改的条数。<br>
+	 * @param tableName 插入的表名
+	 * @param list 列名和值
+	 * @return 实际修改的条数
+	 */
+	int insertBatchWithoutReturnId(String tableName, Collection<Map<String, Object>> list);
+
+	/**
+	 * 以JDBCTemplate的batchUpdate方式，批量插入多条记录，返回数据库实际修改的条数。<br>
+	 * @param tableName 插入的表名
+	 * @param cols 列的列表
+	 * @param values 参数列表
+	 * @return 实际修改的条数
+	 */
+	int insertBatchWithoutReturnId(String tableName, List<String> cols, List<Object[]> values);
+
+	/**
 	 * 插入一条记录，返回数据库实际修改条数。<br>
 	 * 如果包含了自增id，则自增Id会被设置。
 	 * @param t 需要插入的DO对象实例

--- a/nimble-orm/src/main/java/com/pugwoo/dbhelper/impl/part/P2_InsertOp.java
+++ b/nimble-orm/src/main/java/com/pugwoo/dbhelper/impl/part/P2_InsertOp.java
@@ -10,6 +10,7 @@ import com.pugwoo.dbhelper.utils.DOInfoReader;
 import com.pugwoo.dbhelper.utils.Generated;
 import com.pugwoo.dbhelper.utils.InnerCommonUtils;
 import com.pugwoo.dbhelper.utils.PreHandleObject;
+import java.util.Map;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 
 import java.lang.reflect.Field;
@@ -132,10 +133,7 @@ public abstract class P2_InsertOp extends P1_QueryOp {
 			doInterceptBeforeInsertList(list);
 		}
 
-		long start;
-		int total = 0;
-		String sqlForLog;
-		Object paramForLog;
+		int total;
 		DatabaseEnum databaseType = getDatabaseType();
 		/*
 		  特别说明，clickhouse的批量插入不推荐使用insert into values()()()方式，原因：
@@ -150,40 +148,110 @@ public abstract class P2_InsertOp extends P1_QueryOp {
 		if (databaseType == DatabaseEnum.CLICKHOUSE) {
 			List<Object[]> values = new ArrayList<>();
 			String sql = SQLUtils.getInsertSQLForBatchForJDBCTemplate(list, values);
-			sql = addComment(sql);
-			paramForLog = values.isEmpty() ? null : values.get(0);
-			log(sql, values.size(), paramForLog);
-			sqlForLog = sql;
-
-			start = System.currentTimeMillis();
-			int[] rows = jdbcTemplate.batchUpdate(sql, values);
-			for (int row : rows) {
-				int result = row;
-				if (row == -2) {
-					result = 1; // -2 means Statement.SUCCESS_NO_INFO
-				} else if (row < 0) {
-					result = 0; // not success
-				}
-				total += result;
-			}
+			total = insertBatchJDBCTemplateMode(sql, values);
 		} else {
 			List<Object> values = new ArrayList<>();
 			InsertSQLForBatchDTO sqlDTO = SQLUtils.getInsertSQLForBatch(list, values, databaseType);
-			String sql = addComment(sqlDTO.getSql());
-			sqlForLog = sqlDTO.getSql().substring(0, sqlDTO.getSqlLogEndIndex());
-			paramForLog = values.subList(0, sqlDTO.getParamLogEndIndex());
-			log(sqlForLog, list.size(), paramForLog);
-
-			start = System.currentTimeMillis();
-			total = jdbcTemplate.update(sql, values.toArray()); // 此处可以用jdbcTemplate，因为没有in (?)表达式
+			total = insertBatchDefaultMode(sqlDTO, values, list.size());
 		}
-
-		long cost = System.currentTimeMillis() - start;
-		logSlow(cost, sqlForLog, list.size(), paramForLog);
 
 		if (withInterceptor) {
 			doInterceptAfterInsertList(list, total);
 		}
+		return total;
+	}
+
+	private int insertBatchDefaultMode(InsertSQLForBatchDTO sqlDTO, List<Object> values, int listSize) {
+		String sql = addComment(sqlDTO.getSql());
+		String sqlForLog = sqlDTO.getSql().substring(0, sqlDTO.getSqlLogEndIndex());
+		Object paramForLog = values.subList(0, sqlDTO.getParamLogEndIndex());
+		log(sqlForLog, listSize, paramForLog);
+
+		long start = System.currentTimeMillis();
+		int total = jdbcTemplate.update(sql, values.toArray()); // 此处可以用jdbcTemplate，因为没有in (?)表达式
+		long cost = System.currentTimeMillis() - start;
+		logSlow(cost, sqlForLog, listSize, paramForLog);
+		return total;
+	}
+
+	private int insertBatchJDBCTemplateMode(String sql, List<Object[]> values) {
+		sql = addComment(sql);
+		Object paramForLog = values.isEmpty() ? null : values.get(0);
+		log(sql, values.size(), paramForLog);
+		String sqlForLog = sql;
+
+		long start = System.currentTimeMillis();
+		int total = 0;
+		int[] rows = jdbcTemplate.batchUpdate(sql, values);
+		for (int row : rows) {
+			int result = row;
+			if (row == -2) {
+				result = 1; // -2 means Statement.SUCCESS_NO_INFO
+			} else if (row < 0) {
+				result = 0; // not success
+			}
+			total += result;
+		}
+		long cost = System.currentTimeMillis() - start;
+		logSlow(cost, sqlForLog, values.size(), paramForLog);
+		return total;
+	}
+
+	@Override
+	public int insertBatchWithoutReturnId(String tableName, Collection<Map<String, Object>> list) {
+		return insertBatchWithoutReturnId(tableName, list, true);
+	}
+
+	private int insertBatchWithoutReturnId(String tableName, Collection<Map<String, Object>> list,
+			boolean withInterceptor) {
+		list = InnerCommonUtils.filterNonNull(list);
+		if (InnerCommonUtils.isEmpty(list)) {
+			return 0;
+		}
+
+		DatabaseEnum databaseType = getDatabaseType();
+		int total;
+		if (databaseType == DatabaseEnum.CLICKHOUSE) {
+			List<Object[]> values = new ArrayList<>();
+			String sql = SQLUtils.getInsertSQLForBatchForJDBCTemplate(tableName, list, values);
+			total = insertBatchJDBCTemplateMode(sql, values);
+		} else {
+			List<Object> values = new ArrayList<>();
+			InsertSQLForBatchDTO sqlDTO = SQLUtils.getInsertSQLForBatch(tableName, list, values, databaseType);
+			total = insertBatchDefaultMode(sqlDTO, values, list.size());
+		}
+
+		if (withInterceptor) {
+			doInterceptAfterInsertList(list, total);
+		}
+
+		return total;
+	}
+
+	@Override
+	public int insertBatchWithoutReturnId(String tableName, List<String> cols, List<Object[]> values) {
+		return insertBatchWithoutReturnId(tableName, cols, values, true);
+	}
+
+	private int insertBatchWithoutReturnId(String tableName, List<String> cols, List<Object[]> values,
+			boolean withInterceptor) {
+		cols = (List<String>) InnerCommonUtils.filterNonNull(cols);
+		if (InnerCommonUtils.isEmpty(cols)) {
+			return 0;
+		}
+		values = (List<Object[]>) InnerCommonUtils.filterNonNull(values);
+		if (InnerCommonUtils.isEmpty(values)) {
+			return 0;
+		}
+
+		// 用JDBCTemplate的方式
+		String sql = SQLUtils.getInsertSQLForBatchForJDBCTemplate(tableName, cols);
+		int total = insertBatchJDBCTemplateMode(sql, values);
+
+		if (withInterceptor) {
+			doInterceptAfterInsertList(values, total);
+		}
+
 		return total;
 	}
 


### PR DESCRIPTION
有些时候，有些实体的DDL是不确定的、动态的，此时不能使用静态维护的DO进行插入操作。往往此时用户会选择使用能随时控制字段的Map或Object列表作为实体使用。

添加的2个方法，会根据列和数据信息，自动拼装成SQL语句。